### PR TITLE
feat: enhance official guild management functionality

### DIFF
--- a/Discord Stream Notify Bot/Command/Admin/AdministraitonService.cs
+++ b/Discord Stream Notify Bot/Command/Admin/AdministraitonService.cs
@@ -16,5 +16,20 @@
 
             await Task.WhenAll(Task.Delay(1000), textChannel.DeleteMessagesAsync(msgs)).ConfigureAwait(false);
         }
+
+        internal bool WriteOfficialListFile()
+        {
+            try
+            {
+                File.WriteAllText(Program.GetDataFilePath("OfficialList.json"), JsonConvert.SerializeObject(Utility.OfficialGuildList));
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "WriteOfficialListFile Error");
+                return false;
+            }
+
+            return true;
+        }
     }
 }

--- a/Discord Stream Notify Bot/Command/Admin/Administration.cs
+++ b/Discord Stream Notify Bot/Command/Admin/Administration.cs
@@ -297,5 +297,55 @@ namespace Discord_Stream_Notify_Bot.Command.Admin
                 Log.Error(ex.ToString());
             }
         }
+
+        [RequireContext(ContextType.DM)]
+        [Command("AddOfficialList")]
+        [Summary("新增官方伺服器白名單")]
+        [Alias("aol")]
+        [RequireOwner]
+        public async Task AddOfficialListAsync(ulong guildId)
+        {
+            if (Utility.OfficialGuildList.Contains(guildId))
+            {
+                await Context.Channel.SendErrorAsync("此伺服器已存在於名單內");
+                return;
+            }
+
+            Utility.OfficialGuildList.Add(guildId);
+
+            if (_service.WriteOfficialListFile())
+            {
+                await Context.Channel.SendConfirmAsync($"已添加 {guildId} 至官方伺服器名單內");
+            }
+            else
+            {
+                await Context.Channel.SendErrorAsync($"添加 {guildId} 至官方伺服器名單內失敗");
+            }
+        }
+
+        [RequireContext(ContextType.DM)]
+        [Command("RemoveOfficialList")]
+        [Summary("移除官方伺服器白名單")]
+        [Alias("rol")]
+        [RequireOwner]
+        public async Task RemoveOfficialListAsync(ulong guildId)
+        {
+            if (!Utility.OfficialGuildList.Contains(guildId))
+            {
+                await Context.Channel.SendErrorAsync("此伺服器不存在於名單內");
+                return;
+            }
+
+            Utility.OfficialGuildList.Remove(guildId);
+
+            if (_service.WriteOfficialListFile())
+            {
+                await Context.Channel.SendConfirmAsync($"已從官方伺服器名單內移除 {guildId}");
+            }
+            else
+            {
+                await Context.Channel.SendErrorAsync($"從官方伺服器名單內移除 {guildId} 失敗");
+            }
+        }
     }
 }

--- a/Discord Stream Notify Bot/Command/Attribute/RequireGuildMemberCountAttribute.cs
+++ b/Discord Stream Notify Bot/Command/Attribute/RequireGuildMemberCountAttribute.cs
@@ -16,9 +16,15 @@ namespace Discord_Stream_Notify_Bot.Command.Attribute
         {
             if (context.Message.Author.Id == Program.ApplicatonOwner.Id) return Task.FromResult(PreconditionResult.FromSuccess());
 
-            if (((SocketGuild)context.Guild).MemberCount >= GuildMemberCount) return Task.FromResult(PreconditionResult.FromSuccess());
-            else return Task.FromResult(PreconditionResult.FromError($"伺服器人數小於 {GuildMemberCount} 人，不可使用本指令\n" +
-                $"此指令要求伺服器人數須大於等於 {GuildMemberCount} 人"));
+            if (Utility.OfficialGuildList.Contains(context.Guild.Id)) return Task.FromResult(PreconditionResult.FromSuccess());
+
+            var memberCount = ((SocketGuild)context.Guild).MemberCount;
+            if (memberCount >= GuildMemberCount) return Task.FromResult(PreconditionResult.FromSuccess());
+            else return Task.FromResult(PreconditionResult.FromError($"此伺服器不可使用本指令\n" +
+                $"指令要求伺服器人數: `{GuildMemberCount}` 人\n" +
+                $"目前 Bot 所取得的伺服器人數: `{memberCount}` 人\n" +
+                $"由於快取的關係，可能會遇到伺服器人數錯誤的問題\n" +
+                $"如有任何需要請聯繫 Bot 擁有者處理 (你可使用 `/utility send-message-to-bot-owner` 對擁有者發送訊息)"));
         }
     }
 }

--- a/Discord Stream Notify Bot/Interaction/Attribute/RequireGuildMemberCountAttribute.cs
+++ b/Discord Stream Notify Bot/Interaction/Attribute/RequireGuildMemberCountAttribute.cs
@@ -16,6 +16,8 @@ namespace Discord_Stream_Notify_Bot.Interaction.Attribute
         {
             if (context.Interaction.User.Id == Program.ApplicatonOwner.Id) return Task.FromResult(PreconditionResult.FromSuccess());
 
+            if (Discord_Stream_Notify_Bot.Utility.OfficialGuildList.Contains(context.Guild.Id)) return Task.FromResult(PreconditionResult.FromSuccess());
+
             var memberCount = ((SocketGuild)context.Guild).MemberCount;
             if (memberCount >= GuildMemberCount) return Task.FromResult(PreconditionResult.FromSuccess());
             else return Task.FromResult(PreconditionResult.FromError($"此伺服器不可使用本指令\n" +

--- a/Discord Stream Notify Bot/Interaction/Twitch/TwitchSpider.cs
+++ b/Discord Stream Notify Bot/Interaction/Twitch/TwitchSpider.cs
@@ -155,9 +155,9 @@ namespace Discord_Stream_Notify_Bot.Interaction.Twitch
             };
         }
 
-        [RequireGuildMemberCount(500)]
+        [RequireGuildMemberCount(200)]
         [CommandSummary("新增 Twitch 頻道爬蟲\n" +
-           "伺服器需大於 500 人才可使用\n" +
+           "伺服器需大於 200 人才可使用\n" +
            "未來會根據情況增減可新增的頻道數量\n" +
            "如有任何需要請向擁有者詢問")]
         [CommandExample("998rrr", "https://twitch.tv/998rrr")]

--- a/Discord Stream Notify Bot/Interaction/Twitter/TwitterSpaces.cs
+++ b/Discord Stream Notify Bot/Interaction/Twitter/TwitterSpaces.cs
@@ -126,7 +126,7 @@ namespace Discord_Stream_Notify_Bot.Interaction.Twitter
         [CommandSummary("新增推特語音空間開台通知的頻道\n" +
             "請使用@後面的使用者名稱來新增\n" +
             "可以使用`/twitter-space list`查詢有哪些頻道\n")]
-        [CommandExample("margaretthebox", "@inui_toko")]
+        [CommandExample("_998rrr_", "@inui_toko")]
         [SlashCommand("add", "新增推特語音空間開台通知的頻道")]
         public async Task AddChannel([Summary("推特使用者名稱")] string userScreenName,
             [Summary("發送通知的頻道"), ChannelTypes(ChannelType.Text, ChannelType.News)] IChannel channel)
@@ -198,7 +198,7 @@ namespace Discord_Stream_Notify_Bot.Interaction.Twitter
 
         [CommandSummary("移除推特語音空間通知的頻道\n" +
              "請使用@後面的使用者名稱來移除")]
-        [CommandExample("margaretthebox", "@inui_toko")]
+        [CommandExample("_998rrr_", "@inui_toko")]
         [SlashCommand("remove", "移除推特語音空間開台通知的頻道")]
         public async Task RemoveChannel([Summary("推特使用者名稱"), Autocomplete(typeof(GuildNoticeTwitterSpaceIdAutocompleteHandler))] string userScreenName)
         {
@@ -260,7 +260,7 @@ namespace Discord_Stream_Notify_Bot.Interaction.Twitter
             "不輸入通知訊息的話則會關閉通知訊息\n" +
             "需先新增直播通知後才可設定通知訊息(`/help get-command-help twitter-space add`)\n\n" +
             "(考慮到有伺服器需Ping特定用戶組的情況，故Bot需提及所有身分組權限)")]
-        [CommandExample("margaretthebox", "margaretthebox @直播通知 大小姐開語音啦")]
+        [CommandExample("_998rrr_", "_998rrr_ @直播通知 玖玖巴開語音啦")]
         [SlashCommand("set-message", "設定通知訊息")]
         public async Task SetMessage([Summary("推特使用者名稱"), Autocomplete(typeof(GuildNoticeTwitterSpaceIdAutocompleteHandler))] string userScreenName, [Summary("通知訊息")] string message = "")
         {

--- a/Discord Stream Notify Bot/Interaction/Twitter/TwitterSpacesSpider.cs
+++ b/Discord Stream Notify Bot/Interaction/Twitter/TwitterSpacesSpider.cs
@@ -25,7 +25,7 @@ namespace Discord_Stream_Notify_Bot.Interaction.Twitter
             "伺服器需大於 500 人才可使用\n" +
             "未來會根據情況增減可新增的頻道數量\n" +
             "如有任何需要請向擁有者詢問\n")]
-        [CommandExample("margaretthebox", "@inui_toko")]
+        [CommandExample("_998rrr_", "@inui_toko")]
         [SlashCommand("add", "新增推特語音空間爬蟲")]
         public async Task AddSpider([Summary("推特使用者名稱")] string userScreenName)
         {
@@ -98,9 +98,9 @@ namespace Discord_Stream_Notify_Bot.Interaction.Twitter
                     return;
                 }
 
-                if (db.TwitterSpaecSpider.Count((x) => x.GuildId == Context.Guild.Id) >= 5)
+                if (!Discord_Stream_Notify_Bot.Utility.OfficialGuildContains(Context.Guild.Id) && db.TwitterSpaecSpider.Count((x) => x.GuildId == Context.Guild.Id) >= 5)
                 {
-                    await Context.Interaction.SendErrorAsync($"此伺服器已設定五個推特語音空間爬蟲，請移除後再試\n" +
+                    await Context.Interaction.SendErrorAsync($"此伺服器已設定 5 個推特語音空間爬蟲，請移除後再試\n" +
                         $"如有特殊需求請向Bot擁有者詢問", true).ConfigureAwait(false);
                     return;
                 }
@@ -131,7 +131,7 @@ namespace Discord_Stream_Notify_Bot.Interaction.Twitter
 
         [CommandSummary("移除推特語音空間爬蟲\n" +
            "爬蟲必須由本伺服器新增才可移除")]
-        [CommandExample("margaretthebox", "@inui_toko")]
+        [CommandExample("_998rrr_", "@inui_toko")]
         [SlashCommand("remove", "移除推特語音空間爬蟲")]
         public async Task RemoveSpider([Summary("推特使用者名稱"), Autocomplete(typeof(GuildTwitterSpaceSpiderAutocompleteHandler))] string userScreenName)
         {

--- a/Discord Stream Notify Bot/Interaction/YoutubeMember/YoutubeMemberSetting.cs
+++ b/Discord Stream Notify Bot/Interaction/YoutubeMember/YoutubeMemberSetting.cs
@@ -111,10 +111,10 @@ namespace Discord_Stream_Notify_Bot.Interaction.YoutubeMember
             }
         }
 
-        [RequireGuildMemberCount(500)]
-        [CommandSummary("新增會限驗證頻道，目前可上限為 20 個頻道\n" +
+        [RequireGuildMemberCount(250)]
+        [CommandSummary("新增會限驗證頻道，目前可上限為 5 個頻道\n" +
            "如新增同個頻道則可變更要授予的用戶組\n" +
-           "伺服器需大於 500 人才可使用\n" +
+           "伺服器需大於 250 人才可使用\n" +
            "如有任何需要請向擁有者詢問")]
         [CommandExample("https://www.youtube.com/@998rrr @玖桃")]
         [SlashCommand("add-member-check", "新增會限驗證頻道")]
@@ -159,9 +159,9 @@ namespace Discord_Stream_Notify_Bot.Interaction.YoutubeMember
                         db.GuildConfig.Add(guildConfig);
                     }
 
-                    if (db.GuildYoutubeMemberConfig.Count((x) => x.GuildId == Context.Guild.Id) > 20)
+                    if (!Discord_Stream_Notify_Bot.Utility.OfficialGuildContains(Context.Guild.Id) && db.GuildYoutubeMemberConfig.Count((x) => x.GuildId == Context.Guild.Id) > 5)
                     {
-                        await Context.Interaction.SendErrorAsync($"此伺服器已使用 20 個頻道做為會限驗證用\n" +
+                        await Context.Interaction.SendErrorAsync($"此伺服器已使用 5 個頻道做為會限驗證用\n" +
                             $"請移除未使用到的頻道來繼續新增驗證頻道，或是向 Bot 擁有者詢問", true);
                         return;
                     }

--- a/Discord Stream Notify Bot/Program.cs
+++ b/Discord Stream Notify Bot/Program.cs
@@ -76,6 +76,19 @@ namespace Discord_Stream_Notify_Bot
             if (!Directory.Exists(Path.GetDirectoryName(GetDataFilePath(""))))
                 Directory.CreateDirectory(Path.GetDirectoryName(GetDataFilePath("")));
 
+            if (File.Exists(GetDataFilePath("OfficialList.json")))
+            {
+                try
+                {
+                    Utility.OfficialGuildList = JsonConvert.DeserializeObject<HashSet<ulong>>(File.ReadAllText(GetDataFilePath("OfficialList.json")));
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex, "ReadOfficialListFile Error");
+                    return;
+                }
+            }
+
             using (var db = DataBase.MainDbContext.GetDbContext())
                 db.Database.EnsureCreated();
             using (var db = DataBase.HoloVideoContext.GetDbContext())

--- a/Discord Stream Notify Bot/Utility.cs
+++ b/Discord Stream Notify Bot/Utility.cs
@@ -7,6 +7,8 @@
 
         //static Regex videoIdRegex = new Regex(@"youtube_(?'ChannelId'[\w\-]{24})_(?'Date'[\d]{8})_(?'Time'[\d]{6})_(?'VideoId'[\w\-]{11}).mp4.part");
         public static string RedisKey { get; set; } = "";
+        public static HashSet<ulong> OfficialGuildList { get; set; } = new HashSet<ulong>();
+
         public static List<string> GetNowRecordStreamList()
         {
             try
@@ -41,5 +43,8 @@
                 return 0;
             }
         }
+
+        public static bool OfficialGuildContains(ulong guildId) =>
+            OfficialGuildList.Contains(guildId);
     }
 }


### PR DESCRIPTION
- Add a method `WriteOfficialListFile` to handle writing the official guild list to a JSON file with error handling.
- Introduce two commands, `AddOfficialListAsync` and `RemoveOfficialListAsync`, for adding and removing official guilds, respectively.
- Modify member count requirement for commands from `500` to `200` in `TwitchSpider`.
- Change member count requirement for adding member check channels from `500` to `250`.
- Correct the command examples in `TwitterSpaces` and `TwitterSpacesSpider` to include a new username format.
- Update the utility to initialize `OfficialGuildList` from a JSON file and add a method to check if a guild is official.
- Refactor logic to limit the number of official channels or spiders by using a check for official guilds.